### PR TITLE
export LongTimeout type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export const TIMEOUT_MAX = 2147483647; // 2^31-1
 
-class LongTimeout {
+export class LongTimeout {
   private timeout?: NodeJS.Timeout;
   private unreffed: boolean;
 


### PR DESCRIPTION
In order to use `setLongTimeout` the same way we use `setTimeout`, the typescript type for the return type of `setLongTimeout`, `LongTimeout` must be exported, else you have to do what we did over here:

https://github.com/coralproject/talk/blob/72c300e1ee3ec1c15dd0c8bfcec292bb8531e3e7/src/types/long-settimeout.d.ts